### PR TITLE
fix: fix slice init length

### DIFF
--- a/transaction_builder/remote_builder.go
+++ b/transaction_builder/remote_builder.go
@@ -88,7 +88,7 @@ func (tb *TransactionBuilderRemoteABI) BuildTransactionPayload(function string, 
 		argABIs = append(argABIs, abi)
 	}
 
-	typeArgABIs := make([]TypeArgumentABI, len(funcABI.GenericTypeParams))
+	typeArgABIs := make([]TypeArgumentABI, 0, len(funcABI.GenericTypeParams))
 	for idx := range funcABI.GenericTypeParams {
 		typeArgABIs = append(typeArgABIs, TypeArgumentABI{Name: strconv.FormatInt(int64(idx), 10)})
 	}


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of   `len(funcABI.GenericTypeParams)`  rather than initializing the length of this slice.

The online demo: https://go.dev/play/p/q1BcVCmvidW